### PR TITLE
ENH: Update extension metadata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,8 @@ set(EXTENSION_HOMEPAGE "https://github.com/sebastianandress/Slicer-SurfaceFragme
 set(EXTENSION_CATEGORY "Registration")
 set(EXTENSION_CONTRIBUTORS "Sebastian Andreß (LMU Munich)")
 set(EXTENSION_DESCRIPTION "A polydata/model registration and validation method that finds multiple high accuracy similarity zones on a source model deviating less than a definable threshold from a target model.")
-set(EXTENSION_ICONURL "https://raw.githubusercontent.com/sebastianandress/Slicer-SurfaceFragmentsRegistration/master/SurfaceFragmentsRegistration.png")
-set(EXTENSION_SCREENSHOTURLS "https://raw.githubusercontent.com/sebastianandress/Slicer-SurfaceFragmentsRegistration/master/Resources/screenshot1.png")
+set(EXTENSION_ICONURL "https://github.com/sebastianandress/Slicer-SurfaceFragmentsRegistration/raw/master/SurfaceFragmentsRegistration.png")
+set(EXTENSION_SCREENSHOTURLS "https://github.com/sebastianandress/Slicer-SurfaceFragmentsRegistration/raw/master/Resources/screenshot1.png")
 set(EXTENSION_DEPENDS "NA") # Specified as a list or "NA" if no dependencies
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
Consolidate extension metadata based on the corresponding s4ext file organized
in the ExtensionsIndex repository.